### PR TITLE
feat: add array support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ Only a subset of Zod types are supported. The following types are supported:
 - `z.boolean()`
 - `z.date()`
 - `z.object()` (Nested objects are supported)
+- `z.array()` (Arrays of primitives and objects are supported)
 - `z.union()` (Type safety is not guaranteed)
 
 Another major caveat is that no additional validation is performed on the Mongoose schema. It is recommended to use Zod for validation before saving to the database, as well as on retrieval if there are data integrity concerns.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -112,6 +112,32 @@ describe("Creating schema", () => {
 		});
 	});
 
+	describe("Arrays", () => {
+		it("should handle arrays of strings", () => {
+			const obj = z.object({
+				items: z.array(z.string()),
+			});
+			const { schema } = createSchema(obj, "array", mongoose.connection);
+			expect(schema.obj.items).toEqual([String]);
+		});
+
+		it("should handle arrays of objects", () => {
+			const obj = z.object({
+				items: z.array(
+					z.object({
+						name: z.string(),
+						value: z.number(),
+					}),
+				),
+			});
+			const { schema } = createSchema(obj, "array", mongoose.connection);
+			expect(schema.obj.items).toBeInstanceOf(Array);
+			const subSchema = schema.obj.items[0];
+			expect(subSchema.name).toBe(String);
+			expect(subSchema.value).toBe(Number);
+		});
+	});
+
 	describe("Objects", () => {
 		it("Should be able to handle nested objects", async () => {
 			const obj = z.object({


### PR DESCRIPTION
This pull request adds support for handling `z.array()` types in the Zod-to-Mongoose schema conversion, allowing arrays of both primitives and objects to be mapped correctly. The update includes changes to the conversion logic, documentation, and new tests to verify the feature.

### Support for Zod array types

* Updated the conversion logic in `src/index.ts` to handle `ZodArray`, allowing arrays of primitives and arrays of objects to be converted into Mongoose schema definitions.

### Documentation

* Added `z.array()` to the list of supported Zod types in `readme.md`, clarifying that arrays of primitives and objects are now supported.

### Testing

* Added tests in `tests/index.test.ts` to verify that arrays of strings and arrays of objects are correctly handled during schema creation.

### Type imports

* Updated type imports in `src/index.ts` to include `ZodArray` for proper type checking and conversion.